### PR TITLE
Remove leading space from PS command prompt

### DIFF
--- a/profile.ps1
+++ b/profile.ps1
@@ -45,7 +45,7 @@ function prompt {
     $status_string = ""
   }
  
-  Write-Host (" PS " + $(get-location)) -nonewline
+  Write-Host ("PS " + $(get-location)) -nonewline
   Write-Host ($status_string) -nonewline -foregroundcolor Cyan
   Write-Host (">") -nonewline
   return " "


### PR DESCRIPTION
All of the normal output from other scripts and cmdlets do not start with a leading space, so the command prompt ends up sticking over. Aesthetics thing. :) 
